### PR TITLE
[#66] 파이어베이스와 고객 즐겨찾기 데이터 연동

### DIFF
--- a/src/components/FavoriteButton.jsx
+++ b/src/components/FavoriteButton.jsx
@@ -11,6 +11,17 @@ export default function Favorite({ parkingNo }) {
   const favoriteCollectionRef = collection(db, 'favorites');
   const favoriteDocRef = doc(db, 'favorites', userInfo.user.uid);
 
+  async function setFavoriteButton() {
+    const favoriteSnap = await getDoc(favoriteDocRef);
+    const hasCurrentParkingLot = favoriteSnap.data().favoriteList.includes(parkingNo);
+    if (hasCurrentParkingLot) {
+      setIsFavorite(true);
+    } else {
+      setIsFavorite(false);
+    }
+  }
+  setFavoriteButton();
+
   useEffect(() => {
     async function setDataFavoriteList() {
       const favoriteData = await getDocs(favoriteCollectionRef);
@@ -26,17 +37,6 @@ export default function Favorite({ parkingNo }) {
       }
     }
     setDataFavoriteList();
-
-    async function setFavoriteButton() {
-      const favoriteSnap = await getDoc(favoriteDocRef);
-      const hasCurrentParkingLot = favoriteSnap.data().favoriteList.includes(parkingNo);
-      if (hasCurrentParkingLot) {
-        setIsFavorite(true);
-      } else {
-        setIsFavorite(false);
-      }
-    }
-    setFavoriteButton();
   }, []);
 
   async function handleFavorite() {
@@ -79,6 +79,7 @@ const Label = styled.label`
   -webkit-mask-image: url(${icon_favorite});
   mask-image: url(${icon_favorite});
   overflow: hidden;
+  cursor: pointer;
 
   &.favorite {
     background-color: ${theme.colors.yellow};

--- a/src/components/FavoriteButton.jsx
+++ b/src/components/FavoriteButton.jsx
@@ -1,5 +1,8 @@
-import { useState } from 'react';
+import { async } from '@firebase/util';
+import { addDoc, collection, doc, getDocs, setDoc } from 'firebase/firestore';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
+import { db } from '../../Firebase';
 import icon_favorite from '../../public/assets/icons/icon-favorite.svg';
 import theme from '../styles/theme';
 
@@ -43,7 +46,24 @@ const parkingLotData = {
   referenceDate: '2022-11-17',
 };
 
-export default function Favorite() {
+export default function Favorite({ parkingNo }) {
+  const userInfo = JSON.parse(localStorage.getItem('user'));
+  useEffect(() => {
+    function setFavoriteList() {
+      setDoc(
+        doc(db, 'favorites', userInfo.user.uid),
+        {
+          uid: userInfo.user.uid,
+          name: userInfo.user.displayName,
+          favoriteList: [],
+        },
+        { capital: true },
+        { merge: true }
+      );
+    }
+    setFavoriteList();
+  }, []);
+
   const [userFavoriteList, setUserFavoriteList] = useState(userData.favoriteParkingLotId);
   const [isFavorite, SetIsFavorite] = useState(false);
 

--- a/src/components/FavoriteButton.jsx
+++ b/src/components/FavoriteButton.jsx
@@ -1,53 +1,24 @@
 import { async } from '@firebase/util';
-import { addDoc, collection, doc, getDocs, setDoc } from 'firebase/firestore';
+import {
+  addDoc,
+  arrayRemove,
+  arrayUnion,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  setDoc,
+  updateDoc,
+} from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { db } from '../../Firebase';
 import icon_favorite from '../../public/assets/icons/icon-favorite.svg';
 import theme from '../styles/theme';
 
-const userData = {
-  uid: 'user01',
-  userName: '조정현',
-  favoriteParkingLotId: ['350-4-000004', '350-4-000005', '350-4-000006'],
-};
-
-const parkingLotData = {
-  prkplceNo: '205-2-000016',
-  prkplceNm: '은행2동 제4',
-  prkplceSe: '공영',
-  prkplceType: '노외',
-  rdnmadr: '경기도 성남시 중원구 순환로379번길 19',
-  lnmadr: '',
-  prkcmprt: '230',
-  feedingSe: '1',
-  enforceSe: '요일제',
-  operDay: '평일+토요일+공휴일',
-  weekdayOperOpenHhmm: '00:00',
-  weekdayOperColseHhmm: '23:59',
-  satOperOperOpenHhmm: '00:00',
-  satOperCloseHhmm: '23:59',
-  holidayOperOpenHhmm: '00:00',
-  holidayCloseOpenHhmm: '23:59',
-  parkingchrgeInfo: '유료',
-  basicTime: '30',
-  basicCharge: '400',
-  addUnitTime: '10',
-  addUnitCharge: '200',
-  dayCmmtktAdjTime: '24',
-  dayCmmtkt: '6000',
-  monthCmmtkt: '60000',
-  metpay: '신용카드',
-  spcmnt: '경차, 장애인 차량 50프로 할인 등',
-  institutionNm: '성남도시개발공사 노외주차처',
-  phoneNumber: '',
-  latitude: '37.45668625',
-  longitude: '127.1721948',
-  referenceDate: '2022-11-17',
-};
-
 export default function Favorite({ parkingNo }) {
   const userInfo = JSON.parse(localStorage.getItem('user'));
+
   useEffect(() => {
     function setFavoriteList() {
       setDoc(
@@ -64,23 +35,22 @@ export default function Favorite({ parkingNo }) {
     setFavoriteList();
   }, []);
 
-  const [userFavoriteList, setUserFavoriteList] = useState(userData.favoriteParkingLotId);
   const [isFavorite, SetIsFavorite] = useState(false);
 
-  function handleFavorite() {
-    const parkingLotNo = parkingLotData.prkplceNo;
-    if (userFavoriteList.includes(parkingLotNo)) {
-      setUserFavoriteList(
-        userFavoriteList.filter((item) => {
-          return item !== parkingLotNo;
-        })
-      );
+  async function handleFavorite() {
+    const favoriteRef = await getDoc(doc(db, 'favorites', userInfo.user.uid));
+    if (!favoriteRef.data().favoriteList.length) {
+      updateDoc(doc(db, 'favorites', userInfo.user.uid), {
+        favoriteList: arrayUnion(parkingNo),
+      });
+      SetIsFavorite(true);
+      alert('즐겨찾기에 추가되었습니다.');
+    } else {
+      updateDoc(doc(db, 'favorites', userInfo.user.uid), {
+        favoriteList: arrayRemove(parkingNo),
+      });
       SetIsFavorite(false);
       alert('즐겨찾기에서 삭제되었습니다.');
-    } else {
-      setUserFavoriteList([...userFavoriteList, parkingLotNo]);
-      SetIsFavorite(true);
-      alert('즐겨찾기에서 추가되었습니다.');
     }
   }
 

--- a/src/components/UtilButton.jsx
+++ b/src/components/UtilButton.jsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 import theme from '../styles/theme';
 
-export default function UtilButton({ type, width, icon, children, theme, onClick }) {
+export default function UtilButton({ type, width, icon, children, theme, onClick, as }) {
   return (
-    <Button type={type} icon={icon} width={width} theme={theme} onClick={onClick}>
+    <Button as={as} type={type} icon={icon} width={width} theme={theme} onClick={onClick}>
       {children}
     </Button>
   );
@@ -25,11 +25,14 @@ const buttonTheme = {
 };
 
 const Button = styled.button`
+  display: inline-block;
+  padding: 10px 0;
+  margin-bottom: 10px;
   width: ${(props) => props.width}%;
   color: ${(props) => buttonTheme[props.theme].text};
   background-color: ${(props) => buttonTheme[props.theme].backgroundColor};
+  text-align: center;
   font-size: ${theme.fontSizes.subTitle2};
-  padding: 10px 0;
   font-weight: 700;
   border: 0;
   border-radius: 10px;
@@ -42,6 +45,6 @@ const Button = styled.button`
     height: 30px;
     margin-right: 4px;
     background: url(${(props) => props.icon}) no-repeat center center;
-    vertical-align: bottom;
+    vertical-align: sub;
   }
 `;

--- a/src/components/ZipDetail/InfoZip.jsx
+++ b/src/components/ZipDetail/InfoZip.jsx
@@ -25,6 +25,7 @@ export default function InfoZip({
     phoneNumber,
     latitude,
     longitude,
+    parkingNo,
   },
 }) {
   function copyClipboard() {
@@ -56,7 +57,7 @@ export default function InfoZip({
     <InfoZipWrapper>
       <Title>
         <h2>{name}</h2>
-        <FavoriteButton>즐겨찾기 추가</FavoriteButton>
+        <FavoriteButton parkingNo={parkingNo}>즐겨찾기 추가</FavoriteButton>
       </Title>
       <TagWrapper>
         <TagItem text={type} />

--- a/src/components/ZipDetail/InfoZip.jsx
+++ b/src/components/ZipDetail/InfoZip.jsx
@@ -23,6 +23,8 @@ export default function InfoZip({
     addUnitTime,
     addUnitCharge,
     phoneNumber,
+    latitude,
+    longitude,
   },
 }) {
   function copyClipboard() {
@@ -44,6 +46,10 @@ export default function InfoZip({
     } else {
       document.location.href = `tel: ${phoneNumber}`;
     }
+  }
+
+  function naviKakaoMap() {
+    return `location.href='https://map.kakao.com/link/to/${address},${latitude},${longitude}'`;
   }
 
   return (
@@ -86,7 +92,13 @@ export default function InfoZip({
           <UtilButton type="button" width="50" icon={icon_call} theme="dark" onClick={handleCallZip}>
             전화
           </UtilButton>
-          <UtilButton type="button" width="50" icon={icon_navi} theme="default">
+          <UtilButton
+            as="a"
+            width="50"
+            icon={icon_navi}
+            theme="default"
+            href={`https://map.kakao.com/link/to/${address},${latitude},${longitude}`}
+          >
             길안내
           </UtilButton>
         </div>
@@ -114,7 +126,6 @@ const Title = styled.div`
 `;
 
 const TagWrapper = styled.div`
-  /* white-space: nowrap; */
   margin-bottom: 16px;
 `;
 

--- a/src/pages/ZipDetail.jsx
+++ b/src/pages/ZipDetail.jsx
@@ -37,6 +37,8 @@ export default function ZipDetail() {
           addUnitTime: data.addUnitTime,
           addUnitCharge: data.addUnitCharge,
           phoneNumber: data.phoneNumber,
+          latitude: data.latitude,
+          longitude: data.longitude,
         });
         setParkingDatail({
           basicTime: data.basicTime,

--- a/src/pages/ZipDetail.jsx
+++ b/src/pages/ZipDetail.jsx
@@ -39,6 +39,7 @@ export default function ZipDetail() {
           phoneNumber: data.phoneNumber,
           latitude: data.latitude,
           longitude: data.longitude,
+          parkingNo: data.prkplceNo,
         });
         setParkingDatail({
           basicTime: data.basicTime,


### PR DESCRIPTION
## ✨ 구현 기능 명세
- 고객의 즐겨찾기 데이터를 만들고 데이터를 토대로 즐겨찾기 기능 추가
- close : #66 

## 🎁 PR Point
- 파이어베이스 컬렉션에 favorites 항목을 추가했습니다.
- 상세페이지 진입시 favorites에 고객의 즐겨찾기 문서가 있는지 확인합니다.
- 없다면 로컬스토리지에 저장된 고객의 uid로 문서를 만듭니다.
- favoriteList 배열을 확인하여 주차장 코드 여부에 따라 즐겨찾기 버튼의 색을 바꿉니다.
 
## 🕰 소요시간
- 12시간

## 😭 어려웠던 점
- 파이어베이스에 대한 이해가 없어서 데이터를 불러오는데만 거의 반나절이 걸렸습니다.
- 로직이 돌아가게는 짜졌는데 어딘가 효율적이지 않아보여 아쉽습니다.