### PR TITLE
[#75][✨feat] 마이페이지와 상세페이지에 따라 다른 조건으로 리뷰 렌더링

### DIFF
--- a/src/components/Review/DetailReview.jsx
+++ b/src/components/Review/DetailReview.jsx
@@ -6,6 +6,8 @@ import { db } from '../../../Firebase';
 import { doc, collection, getDocs } from 'firebase/firestore';
 import { useState, useEffect } from 'react';
 
+import { useLocation } from 'react-router';
+
 export default function DetailReview({ zipcode }) {
   const [reviews, setReviews] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/components/Review/ReviewBox.jsx
+++ b/src/components/Review/ReviewBox.jsx
@@ -16,7 +16,6 @@ export default function ReviewBox() {
 
   const [data, setData] = useState([]);
 
-  // const [parkingNo, setParkingNo] = useState('');
   const navigate = useNavigate();
 
   //로그인한 유저의 uid 가져오기

--- a/src/pages/NewReview.jsx
+++ b/src/pages/NewReview.jsx
@@ -14,6 +14,8 @@ import { useLocation } from 'react-router';
 
 import { SearchRTDB } from './../components/getDB/ReadDB';
 
+import { useNavigate } from 'react-router';
+
 export default function NewReview() {
   //상세페이지에서 넘겨 받은 주차장 코드
   const location = useLocation();
@@ -42,7 +44,7 @@ export default function NewReview() {
   const userName = JSON.parse(localStorage.getItem('user')).user.displayName;
   const userId = JSON.parse(localStorage.getItem('user')).user.uid;
 
-  //주차장명 저장
+  const navigate = useNavigate();
 
   //시작될 때 한번만 실행
   useEffect(() => {
@@ -89,7 +91,8 @@ export default function NewReview() {
       parkingName: parkingName,
     });
     window.alert('리뷰를 등록하였습니다.');
-    window.location.href = '/mypage/review';
+
+    navigate(-1);
   };
 
   //추천, 비추천 클릭시 알림 띄우기
@@ -141,7 +144,13 @@ export default function NewReview() {
         }}
       ></ReviewInput>
       <LetterNum>{content.length}/200자</LetterNum>
-      <SubmitBtn onClick={createReview}>등록하기</SubmitBtn>
+      <SubmitBtn
+        onClick={() => {
+          createReview();
+        }}
+      >
+        등록하기
+      </SubmitBtn>
     </ReviewWrapper>
   );
 }

--- a/src/pages/ZipDetail.jsx
+++ b/src/pages/ZipDetail.jsx
@@ -10,7 +10,6 @@ export default function ZipDetail() {
   const [parkingInfo, setParkingInfo] = useState({});
   const [parkingDatail, setParkingDatail] = useState({});
   const [latestUpdate, setLatestUpdate] = useState({});
-  // const prkplceNo = props.prkplceNo
 
   useEffect(() => {
     SearchRTDB('prkplceNo', '350-4-000009').then((res) => {


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성해주시면 되겠습니다 -->

## ✨ 구현 기능 명세
- 상세페이지와 마이페이지 각각 조건에 따라 렌더링하기
- 리뷰 로딩중일때와 리뷰가 없을때 메세지 띄우기
- 주차장 코드를 상세페이지에서 넘겨 받아, 리뷰 작성시 함께 저장하기
- 리뷰 작성이 완료되면 해당 상세 페이지로 이동하도록 라우팅
- 마이페이지/리뷰에서 해당 주차장 코드에 해당하는 주차장명 가져와서 띄우기
- 상세 페이지에 리뷰 작성 버튼 추가하기

## 🎁 PR Point
- 상세페이지와 마이페이지에서 리뷰가 잘 조회되는지
- 상세페이지 -> 리뷰작성 페이지 -> 상세페이지 이동이 잘연결되는지

## 🕰 소요시간
1일

## 😭 어려웠던 점
어렵게 생각해서 시간이 많이 걸렸습니다 ㅜ 